### PR TITLE
dotgitfix __init__.py

### DIFF
--- a/src/limberer/__init__.py
+++ b/src/limberer/__init__.py
@@ -266,7 +266,8 @@ def main():
     shutil.copytree(templatepath, absprojpath)
 
     dotgitdir = os.path.join(absprojpath, '.git')
-    shutil.rmtree(dotgitdir)
+    if os.path.exists(dotgitdir):
+      shutil.rmtree(dotgitdir)
 
     projname = os.path.basename(absprojpath)
     if os.path.exists(os.path.join(absprojpath, "project.toml")):


### PR DESCRIPTION
In src/limberer/__init__.py: 269  if .git does not exist an attempt will still be made to remove it, which will raise an exception causing limberer to exit prematurely. 

Adds a check for if .git exists before attempting to remove it. 