### PR TITLE
Fix to __init__.py for missing .git exception

### DIFF
--- a/src/limberer/__init__.py
+++ b/src/limberer/__init__.py
@@ -266,7 +266,8 @@ def main():
     shutil.copytree(templatepath, absprojpath)
 
     dotgitdir = os.path.join(absprojpath, '.git')
-    shutil.rmtree(dotgitdir)
+    if os.path.exists(dotgitdir):
+      shutil.rmtree(dotgitdir)
 
     projname = os.path.basename(absprojpath)
     if os.path.exists(os.path.join(absprojpath, "project.toml")):


### PR DESCRIPTION
src/limberer/__init__.py: 269 missing .git causes limberer to raise an exception up attempting to remove .git

Add check for .git before attempt to remove is made