### PR TITLE
Numbered List Style Fix

### DIFF
--- a/src/limberer/static/assets/core.css
+++ b/src/limberer/static/assets/core.css
@@ -327,11 +327,32 @@ article ul {
 /*weasyprint currently gets this wrong: https://github.com/Kozea/WeasyPrint/issues/1557*/
 article ol {
   list-style-position: outside;
-  padding-left: 0;
-  margin-left: 1rem;
+  list-style-position: inside; /* need inside here or multiple digits shift left past the left margin */
+  padding-left: 1rem;
+  margin-left: -1rem;
 }
+/*
 article ol li::before {
   content: "\00a0\00a0\00a0";
+}*/
+article ol>li:not(:has(p)) { /* bare lists elements that wrap*/
+  text-indent: -1.11rem;
+  padding-left: 1.11rem;
+  margin-left: 0rem;
+}
+article ol>li:has(p) { /* lists that contain <p> */
+  text-indent: -1.11rem;
+  padding-left: 1.11rem
+}
+article ol>li>p {
+  text-indent: 0rem;
+  margin-left: 0rem;
+  padding-left: 0.01rem;
+}
+article ol>li>p:nth-of-type(1) {
+  display: inline;
+  margin-left: 0rem;
+  padding-left: 0rem;
 }
 
 article ul>li {
@@ -431,3 +452,5 @@ article.appendix>.article-body>h1:nth-of-type(1):before {
 div.linenodiv>pre {
   line-height: 125%;
 }
+
+

--- a/src/limberer/static/sections/example.md
+++ b/src/limberer/static/sections/example.md
@@ -26,6 +26,19 @@ Hi there.
 * <a class="xrefn xrefpg" href="#example2-aaah2"></a>
 * [](#example2-aaah2){.xrefn .xrefpg}
 
+1. Hello world
+1. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+1. Lorem ipsum dolor sit amet, consectetur adipiscing elit,  
+   sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+   Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+1. Hello world
+
+<!-- list break -->
+
+1. Hello world
+1. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
 [^aaa]: <https://example.com>
 [^bbb]: wat
 [^ccc]: wat2<br>foo


### PR DESCRIPTION
Hi,

This PR attempts to fix the styling for `<ol>` -based numbered lists.
Prior to this PR, the styling had strange line breaks between them and the number entry (e.g. "1. ", "2. "). This PR corrects that by making the first `<p>` of `<p>`-based numbered lists not be `display: block`.
Additionally, an attempt at matching the indentation to the first character (for single-digit entries). This needed to be done twice as list entries can be `<p>`-wrapped and can be bare. This PR contains an updated example.md displaying numbered lists.